### PR TITLE
Disable tooltips

### DIFF
--- a/Koha/Plugin/Com/PerplexedTheta/SENUX/static_files/src/js/customisations.js
+++ b/Koha/Plugin/Com/PerplexedTheta/SENUX/static_files/src/js/customisations.js
@@ -130,7 +130,7 @@ window.addEventListener("load", event => {
     //unwrapCoverImg();
 
     // add tooltips
-    addBootstrapTooltips();
+    // addBootstrapTooltips();
 });
 
 


### PR DESCRIPTION
This changes the following HTML on opac place request page from: <span class="confirmjs_hold" title="145407" style="padding:.3em">

To:
<span class="confirmjs_hold" data-bs-title="145407" style="padding:.3em">

Which causes the placing of the hold to fail with a 500 error